### PR TITLE
fix: cdp Interceptor 添加 gioId 失效

### DIFF
--- a/GrowingAutotracker/GrowingAutotracker.h
+++ b/GrowingAutotracker/GrowingAutotracker.h
@@ -17,9 +17,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-
 #import "GrowingDynamicProxy.h"
-#import "GrowingRealAutotracker.h"
 #import "GrowingAutotrackConfiguration.h"
 #import "GrowingTrackConfiguration+CdpTracker.h"
 #import <UIKit/UIKit.h>

--- a/GrowingAutotracker/GrowingAutotracker.m
+++ b/GrowingAutotracker/GrowingAutotracker.m
@@ -17,17 +17,15 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-
 #import "GrowingAutotracker.h"
+#import "GrowingRealAutotracker.h"
 #import "GrowingArgumentChecker.h"
-#import "GrowingEventManager.h"
-#import "GrowingTrackConfiguration.h"
 #import "GrowingResourceCustomEvent.h"
 #import "GrowingDispatchManager.h"
 #import "GrowingCdpEventInterceptor.h"
-#import "GrowingTrackConfiguration+CdpTracker.h"
 #import "GrowingLogMacros.h"
 #import "GrowingLogger.h"
+#import "GrowingEventManager.h"
 #import "GrowingSession.h"
 
 #pragma clang diagnostic push

--- a/GrowingAutotracker/GrowingAutotracker.m
+++ b/GrowingAutotracker/GrowingAutotracker.m
@@ -66,6 +66,7 @@ static GrowingAutotracker *sharedInstance = nil;
         sharedInstance.interceptor = [[GrowingCdpEventInterceptor alloc] initWithSourceId:configuration.dataSourceId];
         [[GrowingSession currentSession] addUserIdChangedDelegate:sharedInstance.interceptor];
         [[GrowingEventManager sharedInstance] addInterceptor:sharedInstance.interceptor];
+        [[GrowingSession currentSession] generateVisit];
     });
 }
 

--- a/GrowingTracker/GrowingTracker.h
+++ b/GrowingTracker/GrowingTracker.h
@@ -1,6 +1,6 @@
 //
 //  GrowingCdpRealTracker.h
-//  GrowingAnalytics-Autotracker-AutotrackerCore-Tracker-TrackerCore
+//  GrowingAnalytics-cdp
 //
 //  Created by sheng on 2020/11/24.
 //  Copyright (C) 2017 Beijing Yishu Technology Co., Ltd.

--- a/GrowingTracker/GrowingTracker.h
+++ b/GrowingTracker/GrowingTracker.h
@@ -19,6 +19,7 @@
 
 #import "GrowingDynamicProxy.h"
 #import "GrowingTrackConfiguration+CdpTracker.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface GrowingTracker : GrowingDynamicProxy
@@ -94,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param itemKey 事件发生关联的物品模型Key
 /// @param itemId 事件发生关联的物品模型ID
 /// @param attributes 事件发生时所伴随的维度信息
-- (void)trackCustomEvent:(NSString *)eventName itemKey:(NSString *)itemKey itemId:(NSString *)itemId withAttributes:(NSDictionary <NSString *, NSString *> *)attributes;
+- (void)trackCustomEvent:(NSString *)eventName itemKey:(NSString *)itemKey itemId:(NSString *)itemId withAttributes:(NSDictionary <NSString *, NSString *> * _Nullable)attributes;
 
 ///-------------------------------
 #pragma mark Unavailable

--- a/GrowingTracker/GrowingTracker.m
+++ b/GrowingTracker/GrowingTracker.m
@@ -18,15 +18,15 @@
 //  limitations under the License.
 
 #import "GrowingTracker.h"
+#import "GrowingRealTracker.h"
 #import "GrowingArgumentChecker.h"
-#import "GrowingEventManager.h"
-#import "GrowingTrackConfiguration.h"
 #import "GrowingResourceCustomEvent.h"
 #import "GrowingDispatchManager.h"
 #import "GrowingCdpEventInterceptor.h"
 #import "GrowingLogMacros.h"
 #import "GrowingLogger.h"
-#import "GrowingRealTracker.h"
+#import "GrowingEventManager.h"
+#import "GrowingSession.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wincomplete-implementation"
@@ -82,7 +82,7 @@ static GrowingTracker *sharedInstance = nil;
     [self trackCustomEvent:eventName itemKey:itemKey itemId:itemId withAttributes:nil];
 }
 
-- (void)trackCustomEvent:(NSString *)eventName itemKey:(NSString *)itemKey itemId:(NSString *)itemId withAttributes:(NSDictionary <NSString *, NSString *> *)attributes {
+- (void)trackCustomEvent:(NSString *)eventName itemKey:(NSString *)itemKey itemId:(NSString *)itemId withAttributes:(NSDictionary <NSString *, NSString *> * _Nullable)attributes {
     if ([GrowingArgumentChecker isIllegalEventName:itemKey] || [GrowingArgumentChecker isIllegalEventName:itemId]) {
         return;
     }

--- a/GrowingTracker/GrowingTracker.m
+++ b/GrowingTracker/GrowingTracker.m
@@ -1,6 +1,6 @@
 //
 //  GrowingCdpRealTracker.m
-//  GrowingAnalytics-Autotracker-AutotrackerCore-Tracker-TrackerCore
+//  GrowingAnalytics-cdp
 //
 //  Created by sheng on 2020/11/24.
 //  Copyright (C) 2017 Beijing Yishu Technology Co., Ltd.
@@ -62,8 +62,9 @@ static GrowingTracker *sharedInstance = nil;
         GrowingRealTracker *realTracker = [GrowingRealTracker trackerWithConfiguration:configuration launchOptions:launchOptions];
         sharedInstance = [[self alloc] initWithRealTracker:realTracker];
         sharedInstance.interceptor = [[GrowingCdpEventInterceptor alloc] initWithSourceId:configuration.dataSourceId];
+        [[GrowingSession currentSession] addUserIdChangedDelegate:sharedInstance.interceptor];
         [[GrowingEventManager sharedInstance] addInterceptor:sharedInstance.interceptor];
-        
+        [[GrowingSession currentSession] generateVisit];
     });
 }
 

--- a/GrowingTrackerCore/CDP/GrowingCdpEventInterceptor.h
+++ b/GrowingTrackerCore/CDP/GrowingCdpEventInterceptor.h
@@ -1,6 +1,6 @@
 //
 //  GrowingCdpEventInterceptor.h
-//  GrowingAnalytics-Autotracker-AutotrackerCore-Tracker-TrackerCore
+//  GrowingAnalytics-cdp
 //
 //  Created by sheng on 2020/11/24.
 //  Copyright (C) 2017 Beijing Yishu Technology Co., Ltd.

--- a/GrowingTrackerCore/CDP/GrowingCdpEventInterceptor.m
+++ b/GrowingTrackerCore/CDP/GrowingCdpEventInterceptor.m
@@ -1,6 +1,6 @@
 //
 //  GrowingCdpEventInterceptor.m
-//  GrowingAnalytics-Autotracker-AutotrackerCore-Tracker-TrackerCore
+//  GrowingAnalytics-cdp
 //
 //  Created by sheng on 2020/11/24.
 //  Copyright (C) 2017 Beijing Yishu Technology Co., Ltd.

--- a/GrowingTrackerCore/CDP/GrowingResourceCustomEvent.h
+++ b/GrowingTrackerCore/CDP/GrowingResourceCustomEvent.h
@@ -1,6 +1,6 @@
 //
 //  GrowingResourceCustomEvent.h
-//  GrowingAnalytics-Autotracker-AutotrackerCore-Tracker-TrackerCore
+//  GrowingAnalytics-cdp
 //
 //  Created by sheng on 2020/11/24.
 //  Copyright (C) 2017 Beijing Yishu Technology Co., Ltd.

--- a/GrowingTrackerCore/CDP/GrowingResourceCustomEvent.m
+++ b/GrowingTrackerCore/CDP/GrowingResourceCustomEvent.m
@@ -1,6 +1,6 @@
 //
 //  GrowingResourceCustomEvent.m
-//  GrowingAnalytics-Autotracker-AutotrackerCore-Tracker-TrackerCore
+//  GrowingAnalytics-cdp
 //
 //  Created by sheng on 2020/11/24.
 //  Copyright (C) 2017 Beijing Yishu Technology Co., Ltd.


### PR DESCRIPTION
cdp 在 trackerWithConfiguration:launchOptions: 函数之后才添加的拦截器，用于userId 改变时持久化 gioId 以及发数前添加 gioId；
generateVisit 时机早于拦截器，将使 gioId 未附带上传。

### 测试
cdp 初始化 SDK 后首次发送的 VISIT 事件附带的 gioId、dataSourceId 是否正常。