### PR TITLE
ci: fix xcode13 build error: legacy build system

### DIFF
--- a/GrowingAnalytics-cdp.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/GrowingAnalytics-cdp.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
 	<key>PreviewsEnabled</key>
 	<false/>
 </dict>


### PR DESCRIPTION
## PR 内容

<!-- 在下方描述你的PR实现了什么功能，或者修复了什么问题 -->

修改ci报错，xcode13上legacy build system导致The Legacy Build System will be removed in a future release. You can configure the selected build system and this deprecation message in File > Workspace Settings.


## 测试步骤

<!-- 请描述怎样操作才证明已经处理了问题. -->

无

## 影响范围

<!-- 请描述你的PR能造成的影响范围. -->

无

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

无

